### PR TITLE
FCOM-213: Fixed bugToJson and ToXml null value handling

### DIFF
--- a/Frends.Community.FixedWidthFlatFile.Tests/Frends.Community.FixedWidthFlatFile.Tests.csproj
+++ b/Frends.Community.FixedWidthFlatFile.Tests/Frends.Community.FixedWidthFlatFile.Tests.csproj
@@ -45,6 +45,9 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -52,6 +55,7 @@
     <Compile Include="ParseTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ExtensionTests.cs" />
+    <Compile Include="ResultObjectTests.cs" />
     <Compile Include="UtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
+++ b/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Frends.Community.FixedWidthFlatFile.Tests
+{
+    [TestClass]
+    public class ResultObjectTests
+    {
+        #region Test data creation helper methods
+
+        private ParseResult CreateResultWithEmptyValues()
+        {
+            string fileContent =
+                @"First;Second;Third
+firstValue    ThirdValue";
+
+            var columnSpec = new ColumnSpecification[] {
+                new ColumnSpecification{Length= 10, Type = ColumnType.String},
+                new ColumnSpecification{Length= 4, Type = ColumnType.String},
+                new ColumnSpecification{Length= 10, Type = ColumnType.String}
+            };
+
+            var parseInput = new ParseInput
+            {
+                ColumnSpecifications = columnSpec,
+                FlatFileContent = fileContent,
+                HeaderDelimiter = ";",
+                HeaderRow = HeaderRowType.Delimited
+            };
+            var options = new ParseOptions { SkipRows = false };
+
+            var result = FixedWidthFlatFileTask.Parse(parseInput, options);
+
+            return result;
+        }
+        private ParseResult CreateResultWithDateValue()
+        {
+            string fileContent =
+                @"First;Second;Third
+firstValue    ThirdValue190315";
+
+            var columnSpec = new ColumnSpecification[] {
+                new ColumnSpecification{Length= 10, Type = ColumnType.String},
+                new ColumnSpecification{Length= 4, Type = ColumnType.String},
+                new ColumnSpecification{Length= 10, Type = ColumnType.String},
+                new ColumnSpecification{Length= 6, Type = ColumnType.DateTime, DateTimeFormat ="yyMMdd"}
+            };
+
+            var parseInput = new ParseInput
+            {
+                ColumnSpecifications = columnSpec,
+                FlatFileContent = fileContent,
+                HeaderDelimiter = ";",
+                HeaderRow = HeaderRowType.Delimited
+            };
+            var options = new ParseOptions { SkipRows = false };
+
+            var result = FixedWidthFlatFileTask.Parse(parseInput, options);
+
+            return result;
+        }
+
+        #endregion
+
+        [TestMethod]
+        public void ToXml_WithEmptyValues_DoesNotThrowException()
+        {
+            var parseResult = CreateResultWithEmptyValues();
+
+            var xmlResult = parseResult.ToXml();
+        }
+
+        [TestMethod]
+        public void ToJson_WithEmptyValues_DoesNotThrowException()
+        {
+            var parseResult = CreateResultWithEmptyValues();
+
+            var jsonResult = parseResult.ToJson();
+        }
+
+        [TestMethod]
+        public void ToXml_WithDateTimeValue_DoesNotThrowException()
+        {
+            var parseResult = CreateResultWithDateValue();
+
+            var xmlResult = parseResult.ToXml();
+        }
+
+        [TestMethod]
+        public void ToJson_WithDateTimeValue_DoesNotThrowException()
+        {
+            var parseResult = CreateResultWithDateValue();
+
+            var jsonResult = parseResult.ToJson();
+        }
+
+    }
+}

--- a/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
+++ b/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Frends.Community.FixedWidthFlatFile.Tests
 {
@@ -40,7 +35,7 @@ firstValue    ThirdValue";
         private ParseResult CreateResultWithDateValue()
         {
             string fileContent =
-                @"First;Second;Third
+                @"First;Second;Third;Date
 firstValue    ThirdValue190315";
 
             var columnSpec = new ColumnSpecification[] {
@@ -72,30 +67,36 @@ firstValue    ThirdValue190315";
             var parseResult = CreateResultWithEmptyValues();
 
             var xmlResult = parseResult.ToXml();
+            //check that empty XML element is created
+            Assert.IsTrue(xmlResult.Contains("<Second />"));
         }
 
         [TestMethod]
         public void ToJson_WithEmptyValues_DoesNotThrowException()
         {
             var parseResult = CreateResultWithEmptyValues();
-
             var jsonResult = parseResult.ToJson();
+            // check that empty value is set
+            Assert.AreEqual(jsonResult[0]["Second"], string.Empty);
         }
 
         [TestMethod]
         public void ToXml_WithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
-
             var xmlResult = parseResult.ToXml();
+
+            //check that empty XML element is created
+            Assert.IsTrue(xmlResult.Contains("<Second />"));
         }
 
         [TestMethod]
         public void ToJson_WithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
-
             var jsonResult = parseResult.ToJson();
+            // check that empty value is set
+            Assert.AreEqual(jsonResult[0]["Second"], string.Empty);
         }
 
     }

--- a/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
+++ b/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
@@ -66,6 +66,8 @@ firstValue    ThirdValue190315";
         {
             var parseResult = CreateResultWithEmptyValues();
 
+            Assert.IsTrue(parseResult.Data[0]["Second"] == null);
+
             var xmlResult = parseResult.ToXml();
             //check that empty XML element is created
             Assert.IsTrue(xmlResult.Contains("<Second />"));
@@ -75,6 +77,9 @@ firstValue    ThirdValue190315";
         public void ToJson_WithEmptyValues_DoesNotThrowException()
         {
             var parseResult = CreateResultWithEmptyValues();
+
+            Assert.IsTrue(parseResult.Data[0]["Second"] == null);
+
             var jsonResult = parseResult.ToJson();
             // check that empty value is set
             Assert.AreEqual(jsonResult[0]["Second"], string.Empty);
@@ -84,6 +89,9 @@ firstValue    ThirdValue190315";
         public void ToXml_WithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
+
+            Assert.IsTrue(parseResult.Data[0]["Second"] == null);
+
             var xmlResult = parseResult.ToXml();
 
             //check that empty XML element is created
@@ -94,6 +102,9 @@ firstValue    ThirdValue190315";
         public void ToJson_WithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
+
+            Assert.IsTrue(parseResult.Data[0]["Second"] == null);
+
             var jsonResult = parseResult.ToJson();
             // check that empty value is set
             Assert.AreEqual(jsonResult[0]["Second"], string.Empty);

--- a/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
+++ b/Frends.Community.FixedWidthFlatFile.Tests/ResultObjectTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace Frends.Community.FixedWidthFlatFile.Tests
 {
@@ -85,11 +86,12 @@ firstValue    ThirdValue190315";
             Assert.AreEqual(jsonResult[0]["Second"], string.Empty);
         }
 
+        // Test that null check does not fail with DateTime Type values
         [TestMethod]
-        public void ToXml_WithDateTimeValue_DoesNotThrowException()
+        public void ToXml_NullCheckWithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
-
+            Assert.IsTrue(parseResult.Data[0]["Date"].GetType() == typeof(DateTime));
             Assert.IsTrue(parseResult.Data[0]["Second"] == null);
 
             var xmlResult = parseResult.ToXml();
@@ -98,11 +100,13 @@ firstValue    ThirdValue190315";
             Assert.IsTrue(xmlResult.Contains("<Second />"));
         }
 
+        // Test that null check does not fail with DateTime Type values
         [TestMethod]
-        public void ToJson_WithDateTimeValue_DoesNotThrowException()
+        public void ToJson_NullCheckWithDateTimeValue_DoesNotThrowException()
         {
             var parseResult = CreateResultWithDateValue();
 
+            Assert.IsTrue(parseResult.Data[0]["Date"].GetType() == typeof(DateTime));
             Assert.IsTrue(parseResult.Data[0]["Second"] == null);
 
             var jsonResult = parseResult.ToJson();

--- a/Frends.Community.FixedWidthFlatFile.Tests/packages.config
+++ b/Frends.Community.FixedWidthFlatFile.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net461" />
 </packages>

--- a/Frends.Community.FixedWidthFlatFile/Definitions.cs
+++ b/Frends.Community.FixedWidthFlatFile/Definitions.cs
@@ -128,7 +128,11 @@ namespace Frends.Community.FixedWidthFlatFile
                     foreach (var key in row.Keys)
                     {
                         writer.WritePropertyName(key);
-                        writer.WriteValue(row[key]);
+                        // null check
+                        if (row[key] != null)
+                            writer.WriteValue(row[key]);
+                        else //write empty string value for null fields
+                            writer.WriteValue("");
                     }
 
                     writer.WriteEndObject(); // end row
@@ -157,10 +161,18 @@ namespace Frends.Community.FixedWidthFlatFile
 
                         foreach (var key in row.Keys)
                         {
-                            if (row[key].GetType() == typeof(DateTime))
-                                writer.WriteElementString(key, row[key].ToString("s"));
-                            else
-                                writer.WriteElementString(key, row[key].ToString());
+                            // value null check
+                            if (row[key] != null)
+                            {
+                                if (row[key].GetType() == typeof(DateTime))
+                                    writer.WriteElementString(key, row[key].ToString("s"));
+                                else
+                                    writer.WriteElementString(key, row[key].ToString());
+                            }
+                            else // write empty string for null values
+                            {
+                                writer.WriteElementString(key, "");
+                            }
                         }
 
                         writer.WriteEndElement(); // end Row

--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | ----- | ----- |
 | 1.0.0 | Initial version of Fixed Width Flat File Task |
 | 1.1.0 | Fixed bug where empty rows resulted in exception |
+| 1.2.0 | Fixed bug where ToJson() and ToXml() methods failed with empty/null values |

--- a/nuspec/Frends.Community.FixedWidthFlatFile.nuspec
+++ b/nuspec/Frends.Community.FixedWidthFlatFile.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Frends.Community.FixedWidthFlatFile</id>
-        <version>1.1.2</version>
+        <version>1.2.0</version>
         <title>Frends Community Fixed Width Flat File</title>
         <authors>HiQ Finland</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/nuspec/Frends.Community.FixedWidthFlatFile.nuspec
+++ b/nuspec/Frends.Community.FixedWidthFlatFile.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Frends.Community.FixedWidthFlatFile</id>
-        <version>1.1.0</version>
+        <version>1.1.2</version>
         <title>Frends Community Fixed Width Flat File</title>
         <authors>HiQ Finland</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Fixed bug where ToJson and ToXml threw exception if any value was empty/null.

- Added null check to ToJson() and ToXml() methods
- Added unit tests for these